### PR TITLE
Updating ACI plugin deployment instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,7 +254,7 @@ The plugin you want to add is successfully deployed.
    
    ```
    {
-         "HostName":"aciplugin:45007",
+         "HostName":"aciplugin:45020",
          "UserName":"admin",
          "Password":"Plug!n12$4",
          "Links":{

--- a/README.md
+++ b/README.md
@@ -145,10 +145,10 @@ Kubernetes cluster is set up and the resource aggregator is successfully deploye
 
 7. Generate the Helm package for the Cisco ACI plugin on the deployment node:
 
-   1. Navigate to `PluginCiscoACI/install/Kubernetes/helmcharts/aciplugin`.
+   1. Navigate to `PluginCiscoACI/install/Kubernetes/helmcharts`.
 
       ```
-      $ cd PluginCiscoACI/install/Kubernetes/helmcharts/aciplugin
+      $ cd PluginCiscoACI/install/Kubernetes/helmcharts
       ```
 
    2. Run the following command to create `aciplugin` Helm package at `~/plugins/aciplugin`:
@@ -203,10 +203,9 @@ Kubernetes cluster is set up and the resource aggregator is successfully deploye
 14. Run the following command to install the Cisco ACI plugin: 
 
     ```
-    $ python3 odim-controller.py --config /home/${USER}/ODIM/odim-controller/scripts\
-    /kube_deploy_nodes.yaml --add plugin --plugin aciplugin
+    $ python3 odim-controller.py --config /home/${USER}/ODIM/odim-controller/scripts/kube_deploy_nodes.yaml --add plugin --plugin aciplugin
     ```
-
+    
 15. Run the following command on the cluster nodes to verify the Cisco ACI plugin pod is up and running: 
 
     `$ kubectl get pods -n odim`

--- a/README.md
+++ b/README.md
@@ -171,9 +171,9 @@ Kubernetes cluster is set up and the resource aggregator is successfully deploye
 
 10. Navigate to the `/ODIM/odim-controller/scripts` directory on the deployment node.
 
-   ```
-   $ cd ~/ODIM/odim-controller/scripts
-   ```
+    ```
+    $ cd ~/ODIM/odim-controller/scripts
+    ```
 
 11. Open the `kube_deploy_nodes.yaml` file.
 

--- a/README.md
+++ b/README.md
@@ -39,43 +39,43 @@ Kubernetes cluster is set up and the resource aggregator is successfully deploye
 1. Create a directory called `plugins` on the deployment node.
 
    ```
-   $ mkdir plugins
+   mkdir plugins
    ```
 
 3. In the `plugins` directory, create a directory called `aciplugin`.
 
    ```
-   $ mkdir ~/plugins/aciplugin
+   mkdir ~/plugins/aciplugin
    ```
 
 3. Run the following commands on the deployment node:
 
    1. ```
-      $ git clone https://github.com/ODIM-Project/PluginCiscoACI.git
+      git clone https://github.com/ODIM-Project/PluginCiscoACI.git
       ```
 
    2. ```
-      $ cd PluginCiscoACI/
+      cd PluginCiscoACI/
       ```
 
    3. ```
-      $ ./build_images.sh
+      ./build_images.sh
       ```
 
 4. On the deployment node, copy the Cisco ACI plugin configuration file and the hook script to `~/plugins/aciplugin`.
 
    ```
-   $ cp PluginCiscoACI/install/Kubernetes/helmcharts/aciplugin-config.yaml ~/plugins/aciplugin
+   cp PluginCiscoACI/install/Kubernetes/helmcharts/aciplugin-config.yaml ~/plugins/aciplugin
    ```
 
    ```
-   $ cp PluginCiscoACI/install/Kubernetes/helmcharts/aciplugin.sh ~/plugins/aciplugin
+   cp PluginCiscoACI/install/Kubernetes/helmcharts/aciplugin.sh ~/plugins/aciplugin
    ```
 
 5. Open the Cisco ACI plugin configuration YAML file.
 
    ```
-   $ vi ~/plugins/aciplugin/aciplugin-config.yaml
+   vi ~/plugins/aciplugin/aciplugin-config.yaml
    ```
 
    **Sample aciplugin-config.yaml file:**
@@ -130,7 +130,7 @@ Kubernetes cluster is set up and the resource aggregator is successfully deploye
      To generate the encrypted password, run the following command:
 
      ```
-     $ echo -n '<odimra_password>' \
+     echo -n '<odimra_password>' \
      | openssl pkeyutl -encrypt -inkey \
      ~/R4H60-11004/odim-controller/\
      scripts/certs/\
@@ -148,13 +148,13 @@ Kubernetes cluster is set up and the resource aggregator is successfully deploye
    1. Navigate to `PluginCiscoACI/install/Kubernetes/helmcharts`.
 
       ```
-      $ cd PluginCiscoACI/install/Kubernetes/helmcharts
+      cd PluginCiscoACI/install/Kubernetes/helmcharts
       ```
 
    2. Run the following command to create `aciplugin` Helm package at `~/plugins/aciplugin`:
 
       ```
-      $ helm package aciplugin -d ~/plugins/aciplugin
+      helm package aciplugin -d ~/plugins/aciplugin
       ```
 
       The Helm package for the Cisco ACI plugin is created in the tgz format.
@@ -162,7 +162,7 @@ Kubernetes cluster is set up and the resource aggregator is successfully deploye
 8. Save the Cisco ACI plugin Docker image on the deployment node at `~/plugins/aciplugin`.
 
    ```
-   $ docker save aciplugin:1.0 -o ~/plugins/aciplugin/aciplugin.tar
+   docker save aciplugin:1.0 -o ~/plugins/aciplugin/aciplugin.tar
    ```
 
 9. If it is a three-node cluster configuration, log in to each cluster node and [configure proxy server for the plugin](#configuring-proxy-server-for-a-plugin-version). 
@@ -172,12 +172,12 @@ Kubernetes cluster is set up and the resource aggregator is successfully deploye
 10. Navigate to the `/ODIM/odim-controller/scripts` directory on the deployment node.
 
     ```
-    $ cd ~/ODIM/odim-controller/scripts
+    cd ~/ODIM/odim-controller/scripts
     ```
 
 11. Open the `kube_deploy_nodes.yaml` file.
 
-        $ vi kube_deploy_nodes.yaml
+        vi kube_deploy_nodes.yaml
 
 12. Update the following parameters in the `kube_deploy_nodes.yaml` file to their corresponding values: 
 
@@ -187,29 +187,37 @@ Kubernetes cluster is set up and the resource aggregator is successfully deploye
     | odimraKafkaClientCertFQDNSan | The FQDN to be included in the Kafka client certificate of Resource Aggregator for ODIM for deploying the ACI plugin:<br />`aciplugin`, `aciplugin-events`<br>Add these values to the existing comma-separated list.<br> |
     | odimraServerCertFQDNSan      | The FQDN to be included in the server certificate of Resource Aggregator for ODIM for deploying the ACI plugin:<br /> `aciplugin`, `aciplugin-events`<br> Add these values to the existing comma-separated list.<br> |
 
-         Example:
-         
-         odimPluginPath: /home/bruce/plugins
-          connectionMethodConf:
-          - ConnectionMethodType: Redfish
-            ConnectionMethodVariant: Fabric:BasicAuth:ACI_v1.0.0
-          odimraKafkaClientCertFQDNSan: aciplugin,aciplugin-events
-          odimraServerCertFQDNSan: aciplugin,aciplugin-events
-
-13. Run the following command: 
-
-        $ python3 odim-controller.py --config /home/${USER}/ODIM/odim-controller/scripts/kube_deploy_nodes.yaml --upgrade odimra-config
-
-14. Run the following command to install the Cisco ACI plugin: 
-
-    ```
-    $ python3 odim-controller.py --config /home/${USER}/ODIM/odim-controller/scripts/kube_deploy_nodes.yaml --add plugin --plugin aciplugin
-    ```
+        odimPluginPath: /home/bruce/plugins
+         connectionMethodConf:
+         - ConnectionMethodType: Redfish
+           ConnectionMethodVariant: Fabric:BasicAuth:ACI_v1.0.0
+        odimraKafkaClientCertFQDNSan: aciplugin,aciplugin-events
+        odimraServerCertFQDNSan: aciplugin,aciplugin-events
     
-15. Run the following command on the cluster nodes to verify the Cisco ACI plugin pod is up and running: 
+13. Move odimra_kafka_client.key and odimra_kafka_client.crt stored in odimCertsPath to a different folder.
+
+    <blockquote>NOTE: odimCertsPath is the absolute path of the directory where certificates required by the services of Resource Aggregator for ODIM are present.</blockquote>
+
+14. Update odimra-secrets:
+
+       ```
+    python3 odim-controller.py --config /home/${USER}/ODIM/odim-controller/scripts/kube_deploy_nodes.yaml --upgrade odimra-secret
+       ```
+
+15. Run the following command: 
+
+        python3 odim-controller.py --config /home/${USER}/ODIM/odim-controller/scripts/kube_deploy_nodes.yaml --upgrade odimra-config
+
+16. Run the following command to install the Cisco ACI plugin: 
 
     ```
-    $ kubectl get pods -n odim
+    python3 odim-controller.py --config /home/${USER}/ODIM/odim-controller/scripts/kube_deploy_nodes.yaml --add plugin --plugin aciplugin
+    ```
+
+17. Run the following command on the cluster nodes to verify the Cisco ACI plugin pod is up and running: 
+
+    ```
+    kubectl get pods -n odim
     ```
 
     Example output showing the Cisco ACI plugin pod details:
@@ -218,7 +226,7 @@ Kubernetes cluster is set up and the resource aggregator is successfully deploye
     | ------------------------- | ----- | ------- | -------- | ----- |
     | aciplugin-5fc4b6788-2xx97 | 1/1   | Running | 0        | 4d22h |
 
-16. [Add the Cisco ACI plugin into the Resource Aggregator for ODIM framework](#adding-a-plugin-into-the-resource-aggregator-for-odim-framework). 
+18. [Add the Cisco ACI plugin into the Resource Aggregator for ODIM framework](#adding-a-plugin-into-the-resource-aggregator-for-odim-framework). 
 
 ## Adding a plugin into the Resource Aggregator for ODIM framework
 
@@ -293,7 +301,7 @@ The plugin you want to add is successfully deployed.
        NOTE: To generate a base64 encoded string of `{odim_username:odim_password}`, run the following command:</blockquote>
    
    ```
-   $ echo -n '{odim_username}:{odim_password}' | base64 -w0
+   echo -n '{odim_username}:{odim_password}' | base64 -w0
    ```
    
    Replace `{base64_encoded_string_of_[odim_username:odim_password]}` with the generated base64 encoded string in the curl command. You will receive:
@@ -372,19 +380,19 @@ The plugin you want to add is successfully deployed.
 1. Log in to each cluster node and navigate to the following path: 
 
    ```
-   $ cd /opt/nginx/servers
+   cd /opt/nginx/servers
    ```
 
 2. Create a plugin configuration file called `<plugin-name>_nginx_server.conf`: 
 
    ```
-   $ vi <plugin-name>_nginx_server.conf
+   vi <plugin-name>_nginx_server.conf
    ```
 
    Example:
 
    ```
-   $ vi aciplugin_nginx_server.conf
+   vi aciplugin_nginx_server.conf
    ```
 
 3. Copy the following content into the `<plugin-name>_nginx_server.conf` file on each cluster node: 
@@ -429,7 +437,7 @@ The plugin you want to add is successfully deployed.
 4. Restart Nginx systemd service only on the leader node \(cluster node where Keepalived priority is set to a higher number\): 
 
    ```
-   $ sudo systemctl restart nginx
+   sudo systemctl restart nginx
    ```
 
    <blockquote>

--- a/README.md
+++ b/README.md
@@ -65,11 +65,11 @@ Kubernetes cluster is set up and the resource aggregator is successfully deploye
 4. On the deployment node, copy the Cisco ACI plugin configuration file and the hook script to `~/plugins/aciplugin`.
 
    ```
-   $ cp install/Kubernetes/helmcharts/aciplugin/aciplugin-config.yaml ~/plugins/aciplugin
+   $ cp PluginCiscoACI/install/Kubernetes/helmcharts/aciplugin/aciplugin-config.yaml ~/plugins/aciplugin
    ```
 
    ```
-   $ cp install/Kubernetes/helmcharts/aciplugin/aciplugin.sh ~/plugins/aciplugin
+   $ cp PluginCiscoACI/install/Kubernetes/helmcharts/aciplugin/aciplugin.sh ~/plugins/aciplugin
    ```
 
 5. Open the Cisco ACI plugin configuration YAML file.

--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ Kubernetes cluster is set up and the resource aggregator is successfully deploye
 
 11. Open the `kube_deploy_nodes.yaml` file.
 
-         $ vi kube_deploy_nodes.yaml
+        $ vi kube_deploy_nodes.yaml
 
 12. Update the following parameters in the `kube_deploy_nodes.yaml` file to their corresponding values: 
 
@@ -208,7 +208,9 @@ Kubernetes cluster is set up and the resource aggregator is successfully deploye
     
 15. Run the following command on the cluster nodes to verify the Cisco ACI plugin pod is up and running: 
 
-    `$ kubectl get pods -n odim`
+    ```
+    $ kubectl get pods -n odim
+    ```
 
     Example output showing the Cisco ACI plugin pod details:
 

--- a/README.md
+++ b/README.md
@@ -48,23 +48,17 @@ Kubernetes cluster is set up and the resource aggregator is successfully deploye
    $ mkdir ~/plugins/aciplugin
    ```
 
-4. Log in to each cluster node and run the following commands: 
-
-   ```
-   $ sudo mkdir -p /var/log/aciplugin_logs/
-   ```
-
-   ```
-   $ sudo chown odimra:odimra /var/log/aciplugin_logs
-   ```
-
-5. On the deployment node, copy the Cisco ACI plugin configuration file to `~/plugins/aciplugin`.
+4. On the deployment node, copy the Cisco ACI plugin configuration file and the hook script to `~/plugins/aciplugin`.
 
    ```
    $ cp ~/ODIM/odim-controller/helmcharts/aciplugin/aciplugin-config.yaml ~/plugins/aciplugin
    ```
 
-5. Open the Cisco ACI plugin configuration YAML file.
+   ```
+   $ cp ~/ODIM/odim-controller/helmcharts/aciplugin/aciplugin.sh ~/plugins/aciplugin
+   ```
+
+4. Open the Cisco ACI plugin configuration YAML file.
 
    ```
    $ vi ~/plugins/aciplugin/aciplugin-config.yaml
@@ -93,34 +87,34 @@ Kubernetes cluster is set up and the resource aggregator is successfully deploye
     odimUserName: admin
     odimPassword: Od!m12$4
    ```
-   
-8. Update the following parameters in the plugin configuration file:
+
+5. Update the following parameters in the plugin configuration file:
 
    - **eventListenerNodePort**: The port used for listening to the ACI plugin events. Default port is 30086.
-   
+
    - **aciPluginRootServiceUUID**: The RootServiceUUID to be used by the ACI plugin service. To generate an UUID, run the following command:
-   
+
      `uuidgen`
-   
+
      Copy the output and paste it as the value for rootServiceUUID.
-   
+
    - **lbHost**: Default value is aciplugin for one node cluster configuration.  For three node cluster configuration,  \(haDeploymentEnabled is true\), lbHost is the virtual IP address configured in Nginx and Keepalived.
-   
+
    - **lbPort**: Default port is 30086. It is the same as eventListenerNodePort for one node cluster configuration. For three node cluster configuration, \(haDeploymentEnabled is true\), lbPort is the Nginx API node port configured in the Nginx plugin configuration file.
-   
+
    - **apicHost**: The IP address of the machine where Cisco APIC UI is launched.
-   
+
    - **apicUserName**: The Cisco APIC username.
-   
+
    - **apicPassword**: The Cisco APIC password.
-   
+
    - **odimURL**: The URL of the ODIMRA API service. URL is https://api:45000.
-   
+
    - **odimUserName**: The username of the default administrator account of Resource Aggregator for ODIM.
-   
+
    - **odimPassword**: The encrypted password of the default administrator account of Resource Aggregator for ODIM.
      To generate the encrypted password, run the following command:
-   
+
      ```
      $ echo -n '<odimra_password>' \
      | openssl pkeyutl -encrypt -inkey \
@@ -132,10 +126,10 @@ Kubernetes cluster is set up and the resource aggregator is successfully deploye
      \
      base64 -A
      ```
-   
+
    Other parameters can have default values. Optionally, you can update them with values based on your requirements. For more information on each parameter, see [Plugin configuration parameters](#plugin-configuration-parameters).
-   
-9. Generate the Helm package for the Cisco ACI plugin on the deployment node:
+
+6. Generate the Helm package for the Cisco ACI plugin on the deployment node:
 
    1. Navigate to `odim-controller/helmcharts/aciplugin`.
 
@@ -151,27 +145,27 @@ Kubernetes cluster is set up and the resource aggregator is successfully deploye
 
       The Helm package for the Cisco ACI plugin is created in the tgz format.
 
-8. Save the Cisco ACI plugin Docker image on the deployment node at `~/plugins/aciplugin`.
+7. Save the Cisco ACI plugin Docker image on the deployment node at `~/plugins/aciplugin`.
 
    ```
    $ sudo docker save aciplugin:1.0 -o ~/plugins/aciplugin/aciplugin.tar
    ```
 
-9. If it is a three-node cluster configuration, log in to each cluster node and [configure proxy server for the plugin](#configuring-proxy-server-for-a-plugin-version). 
+8. If it is a three-node cluster configuration, log in to each cluster node and [configure proxy server for the plugin](#configuring-proxy-server-for-a-plugin-version). 
 
    Skip this step if it is a one-node cluster configuration.
 
-10. Navigate to the `/ODIM/odim-controller/scripts` directory on the deployment node.
+9. Navigate to the `/ODIM/odim-controller/scripts` directory on the deployment node.
 
-    ```
-	$ cd ~/ODIM/odim-controller/scripts
-    ```
-    
-12. Open the `kube_deploy_nodes.yaml` file.
+   ```
+   $ cd ~/ODIM/odim-controller/scripts
+   ```
+
+10. Open the `kube_deploy_nodes.yaml` file.
 
          $ vi kube_deploy_nodes.yaml
-    
-12. Update the following parameters in the `kube_deploy_nodes.yaml` file to their corresponding values: 
+
+11. Update the following parameters in the `kube_deploy_nodes.yaml` file to their corresponding values: 
 
     | Parameter                    | Value                                                        |
     | ---------------------------- | ------------------------------------------------------------ |
@@ -188,18 +182,18 @@ Kubernetes cluster is set up and the resource aggregator is successfully deploye
           odimraKafkaClientCertFQDNSan: aciplugin,aciplugin-events
           odimraServerCertFQDNSan: aciplugin,aciplugin-events
 
-13. Run the following command: 
+12. Run the following command: 
 
         $ python3 odim-controller.py --config /home/${USER}/ODIM/odim-controller/scripts/kube_deploy_nodes.yaml --upgrade odimra-config
 
-14. Run the following command to install the Cisco ACI plugin: 
+13. Run the following command to install the Cisco ACI plugin: 
 
     ```
     $ python3 odim-controller.py --config /home/${USER}/ODIM/odim-controller/scripts\
     /kube_deploy_nodes.yaml --add plugin --plugin aciplugin
     ```
 
-15. Run the following command on the cluster nodes to verify the Cisco ACI plugin pod is up and running: 
+14. Run the following command on the cluster nodes to verify the Cisco ACI plugin pod is up and running: 
 
     `$ kubectl get pods -n odim`
 
@@ -209,7 +203,7 @@ Kubernetes cluster is set up and the resource aggregator is successfully deploye
     | ------------------------- | ----- | ------- | -------- | ----- |
     | aciplugin-5fc4b6788-2xx97 | 1/1   | Running | 0        | 4d22h |
 
-16. [Add the Cisco ACI plugin into the Resource Aggregator for ODIM framework](#adding-a-plugin-into-the-resource-aggregator-for-odim-framework). 
+15. [Add the Cisco ACI plugin into the Resource Aggregator for ODIM framework](#adding-a-plugin-into-the-resource-aggregator-for-odim-framework). 
 
 ## Adding a plugin into the Resource Aggregator for ODIM framework
 

--- a/README.md
+++ b/README.md
@@ -48,17 +48,31 @@ Kubernetes cluster is set up and the resource aggregator is successfully deploye
    $ mkdir ~/plugins/aciplugin
    ```
 
+3. Run the following commands on the deployment node:
+
+   1. ```
+      $ git clone https://github.com/ODIM-Project/PluginCiscoACI.git
+      ```
+
+   2. ```
+      $ cd PluginCiscoACI/
+      ```
+
+   3. ```
+      $ ./build_images.sh
+      ```
+
 4. On the deployment node, copy the Cisco ACI plugin configuration file and the hook script to `~/plugins/aciplugin`.
 
    ```
-   $ cp ~/ODIM/odim-controller/helmcharts/aciplugin/aciplugin-config.yaml ~/plugins/aciplugin
+   $ cp install/Kubernetes/helmcharts/aciplugin/aciplugin-config.yaml ~/plugins/aciplugin
    ```
 
    ```
-   $ cp ~/ODIM/odim-controller/helmcharts/aciplugin/aciplugin.sh ~/plugins/aciplugin
+   $ cp install/Kubernetes/helmcharts/aciplugin/aciplugin.sh ~/plugins/aciplugin
    ```
 
-4. Open the Cisco ACI plugin configuration YAML file.
+5. Open the Cisco ACI plugin configuration YAML file.
 
    ```
    $ vi ~/plugins/aciplugin/aciplugin-config.yaml
@@ -88,7 +102,7 @@ Kubernetes cluster is set up and the resource aggregator is successfully deploye
     odimPassword: Od!m12$4
    ```
 
-5. Update the following parameters in the plugin configuration file:
+6. Update the following parameters in the plugin configuration file:
 
    - **eventListenerNodePort**: The port used for listening to the ACI plugin events. Default port is 30086.
 
@@ -98,7 +112,7 @@ Kubernetes cluster is set up and the resource aggregator is successfully deploye
 
      Copy the output and paste it as the value for rootServiceUUID.
 
-   - **lbHost**: Default value is aciplugin for one node cluster configuration.  For three node cluster configuration,  \(haDeploymentEnabled is true\), lbHost is the virtual IP address configured in Nginx and Keepalived.
+   - **lbHost**: Default value is aciplugin for one node cluster configuration.  For three node cluster configuration, (haDeploymentEnabled is true\), lbHost is the virtual IP address configured in Nginx and Keepalived.
 
    - **lbPort**: Default port is 30086. It is the same as eventListenerNodePort for one node cluster configuration. For three node cluster configuration, \(haDeploymentEnabled is true\), lbPort is the Nginx API node port configured in the Nginx plugin configuration file.
 
@@ -129,12 +143,12 @@ Kubernetes cluster is set up and the resource aggregator is successfully deploye
 
    Other parameters can have default values. Optionally, you can update them with values based on your requirements. For more information on each parameter, see [Plugin configuration parameters](#plugin-configuration-parameters).
 
-6. Generate the Helm package for the Cisco ACI plugin on the deployment node:
+7. Generate the Helm package for the Cisco ACI plugin on the deployment node:
 
-   1. Navigate to `odim-controller/helmcharts/aciplugin`.
+   1. Navigate to `PluginCiscoACI/install/Kubernetes/helmcharts/aciplugin`.
 
       ```
-      $ cd ~/ODIM/odim-controller/helmcharts/aciplugin
+      $ cd PluginCiscoACI/install/Kubernetes/helmcharts/aciplugin
       ```
 
    2. Run the following command to create `aciplugin` Helm package at `~/plugins/aciplugin`:
@@ -145,27 +159,27 @@ Kubernetes cluster is set up and the resource aggregator is successfully deploye
 
       The Helm package for the Cisco ACI plugin is created in the tgz format.
 
-7. Save the Cisco ACI plugin Docker image on the deployment node at `~/plugins/aciplugin`.
+8. Save the Cisco ACI plugin Docker image on the deployment node at `~/plugins/aciplugin`.
 
    ```
-   $ sudo docker save aciplugin:1.0 -o ~/plugins/aciplugin/aciplugin.tar
+   $ docker save aciplugin:1.0 -o ~/plugins/aciplugin/aciplugin.tar
    ```
 
-8. If it is a three-node cluster configuration, log in to each cluster node and [configure proxy server for the plugin](#configuring-proxy-server-for-a-plugin-version). 
+9. If it is a three-node cluster configuration, log in to each cluster node and [configure proxy server for the plugin](#configuring-proxy-server-for-a-plugin-version). 
 
    Skip this step if it is a one-node cluster configuration.
 
-9. Navigate to the `/ODIM/odim-controller/scripts` directory on the deployment node.
+10. Navigate to the `/ODIM/odim-controller/scripts` directory on the deployment node.
 
    ```
    $ cd ~/ODIM/odim-controller/scripts
    ```
 
-10. Open the `kube_deploy_nodes.yaml` file.
+11. Open the `kube_deploy_nodes.yaml` file.
 
          $ vi kube_deploy_nodes.yaml
 
-11. Update the following parameters in the `kube_deploy_nodes.yaml` file to their corresponding values: 
+12. Update the following parameters in the `kube_deploy_nodes.yaml` file to their corresponding values: 
 
     | Parameter                    | Value                                                        |
     | ---------------------------- | ------------------------------------------------------------ |
@@ -182,18 +196,18 @@ Kubernetes cluster is set up and the resource aggregator is successfully deploye
           odimraKafkaClientCertFQDNSan: aciplugin,aciplugin-events
           odimraServerCertFQDNSan: aciplugin,aciplugin-events
 
-12. Run the following command: 
+13. Run the following command: 
 
         $ python3 odim-controller.py --config /home/${USER}/ODIM/odim-controller/scripts/kube_deploy_nodes.yaml --upgrade odimra-config
 
-13. Run the following command to install the Cisco ACI plugin: 
+14. Run the following command to install the Cisco ACI plugin: 
 
     ```
     $ python3 odim-controller.py --config /home/${USER}/ODIM/odim-controller/scripts\
     /kube_deploy_nodes.yaml --add plugin --plugin aciplugin
     ```
 
-14. Run the following command on the cluster nodes to verify the Cisco ACI plugin pod is up and running: 
+15. Run the following command on the cluster nodes to verify the Cisco ACI plugin pod is up and running: 
 
     `$ kubectl get pods -n odim`
 
@@ -203,7 +217,7 @@ Kubernetes cluster is set up and the resource aggregator is successfully deploye
     | ------------------------- | ----- | ------- | -------- | ----- |
     | aciplugin-5fc4b6788-2xx97 | 1/1   | Running | 0        | 4d22h |
 
-15. [Add the Cisco ACI plugin into the Resource Aggregator for ODIM framework](#adding-a-plugin-into-the-resource-aggregator-for-odim-framework). 
+16. [Add the Cisco ACI plugin into the Resource Aggregator for ODIM framework](#adding-a-plugin-into-the-resource-aggregator-for-odim-framework). 
 
 ## Adding a plugin into the Resource Aggregator for ODIM framework
 

--- a/README.md
+++ b/README.md
@@ -65,11 +65,11 @@ Kubernetes cluster is set up and the resource aggregator is successfully deploye
 4. On the deployment node, copy the Cisco ACI plugin configuration file and the hook script to `~/plugins/aciplugin`.
 
    ```
-   $ cp PluginCiscoACI/install/Kubernetes/helmcharts/aciplugin/aciplugin-config.yaml ~/plugins/aciplugin
+   $ cp PluginCiscoACI/install/Kubernetes/helmcharts/aciplugin-config.yaml ~/plugins/aciplugin
    ```
 
    ```
-   $ cp PluginCiscoACI/install/Kubernetes/helmcharts/aciplugin/aciplugin.sh ~/plugins/aciplugin
+   $ cp PluginCiscoACI/install/Kubernetes/helmcharts/aciplugin.sh ~/plugins/aciplugin
    ```
 
 5. Open the Cisco ACI plugin configuration YAML file.


### PR DESCRIPTION
Updating ACI plugin deployment instructions by removing instructions for creating log dirs and adding the hook script information.