### PR TITLE
Updating relevant feedback items given for the plugin sections in the Getting Started readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,11 +205,18 @@ Kubernetes cluster is set up and the resource aggregator is successfully deploye
     | odimraServerCertFQDNSan      | The FQDN to be included in the server certificate of Resource Aggregator for ODIM for deploying the ACI plugin:<br /> `aciplugin`, `aciplugin-events`<br> Add these values to the existing comma-separated list.<br> |
 
         odimPluginPath: /home/bruce/plugins
-         connectionMethodConf:
-         - ConnectionMethodType: Redfish
-           ConnectionMethodVariant: Fabric:BasicAuth:ACI_v1.0.0
-        odimraKafkaClientCertFQDNSan: aciplugin,aciplugin-events
-        odimraServerCertFQDNSan: aciplugin,aciplugin-events
+        odimra:
+          groupID: 2021
+          userID: 2021
+          namespace: odim
+          fqdn:
+          rootServiceUUID:
+          haDeploymentEnabled: True
+          connectionMethodConf:
+          - ConnectionMethodType: Redfish
+            ConnectionMethodVariant: Fabric:BasicAuth:ACI_v1.0.0
+          odimraKafkaClientCertFQDNSan: aciplugin,aciplugin-events
+          odimraServerCertFQDNSan: aciplugin,aciplugin-events
 
 14. Move odimra_kafka_client.key, odimra_kafka_client.crt, odimra_server.key and odimra_server.crt stored in odimCertsPath to a different folder.
 
@@ -321,18 +328,19 @@ The plugin you want to add is successfully deployed.
    echo -n '{odim_username}:{odim_password}' | base64 -w0
    ```
    
+   Default username is `admin` and default password is `Od!m12$4`.
    Replace `{base64_encoded_string_of_[odim_username:odim_password]}` with the generated base64 encoded string in the curl command. You will receive:
    
       -   An HTTP `202 Accepted` status code.
-      -   A link to the task monitor associated with this operation in the response header.
+      -   A link of the executed task. Performing a `GET` operation on this link displays the task monitor associated with this operation in the response header.
    
-      To know the status of this task, perform HTTP `GET` on the `taskmon` URI until the task is complete. If the plugin is added successfully, you will receive an HTTP `200 OK` status code.
+   To know the status of this task, perform HTTP `GET` on the `taskmon` URI until the task is complete. If the plugin is added successfully, you will receive an HTTP `200 OK` status code.
    
    After the plugin is successfully added, it will also be available as a manager resource at:
    
       `/redfish/v1/Managers`
    
-   For more information, refer to "Adding a plugin" in the [Resource Aggregator for Open Distributed Infrastructure Management™ API Reference and User Guide](https://github.com/ODIM-Project/ODIM/tree/development/docs).  
+   For more information, refer to "Adding a plugin" in the [Resource Aggregator for Open Distributed Infrastructure Management™ API Reference and User Guide](https://github.com/ODIM-Project/ODIM/tree/development/docs). 
    
 2. To verify that the added plugin is active and running, do the following: 
 

--- a/README.md
+++ b/README.md
@@ -173,14 +173,14 @@ Kubernetes cluster is set up and the resource aggregator is successfully deploye
 8. Save the Cisco ACI plugin Docker image on the deployment node at `~/plugins/aciplugin`.
 
    ```
-   docker save aciplugin:2.0 -o ~/plugins/aciplugin/aciplugin.tar
+   docker save aciplugin:3.0 -o ~/plugins/aciplugin/aciplugin.tar
    ```
 
 9. Navigate to the `PluginCiscoACI` directory.
 
     ```
    cd ~/PluginCiscoACI
-    ```
+   ```
 
 10. Copy the proxy configuration file `install/templates/aciplugin_proxy_server.conf.j2` to `~/plugins/aciplugin`.
 

--- a/README.md
+++ b/README.md
@@ -176,9 +176,19 @@ Kubernetes cluster is set up and the resource aggregator is successfully deploye
    docker save aciplugin:2.0 -o ~/plugins/aciplugin/aciplugin.tar
    ```
 
-10. Save the proxy configuration file `install/templates/aciplugin_proxy_server.conf.j2` to `~/plugins/aciplugin`.
+9. Navigate to the `PluginCiscoACI` directory.
 
-   **Important**: Do NOT change the value of any parameter in this file. 
+    ```
+   cd ~/PluginCiscoACI
+    ```
+
+10. Copy the proxy configuration file `install/templates/aciplugin_proxy_server.conf.j2` to `~/plugins/aciplugin`.
+
+    ```
+    cp install/templates/aciplugin_proxy_server.conf.j2 ~/plugins/aciplugin
+    ```
+
+    **Important**: Do NOT change the value of any parameter in this file. 
 
 11. Navigate to the `/ODIM/odim-controller/scripts` directory on the deployment node.
 

--- a/README.md
+++ b/README.md
@@ -283,7 +283,7 @@ The plugin you want to add is successfully deployed.
          "Password":"Plug!n12$4",
          "Links":{
                  "ConnectionMethod": {
-                   "@odata.id": "/redfish/v1/AggregationService/ConnectionMethods/d172e66c-b4a8-437c-981b-1c07ddfeacaa"
+                   "@odata.id": "/redfish/v1/AggregationService/ConnectionMethods/{ConnectionMethodId}"
                }
          }
       }

--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ Kubernetes cluster is set up and the resource aggregator is successfully deploye
 
         vi kube_deploy_nodes.yaml
 
-13. Update the following parameters in the `kube_deploy_nodes.yaml` file to their corresponding values: 
+13. Specify values for the following parameters in the `kube_deploy_nodes.yaml` file: 
 
     | Parameter                    | Value                                                        |
     | ---------------------------- | ------------------------------------------------------------ |

--- a/README.md
+++ b/README.md
@@ -170,13 +170,7 @@ Kubernetes cluster is set up and the resource aggregator is successfully deploye
 
       The Helm package for the Cisco ACI plugin is created in the tgz format.
 
-8. Navigate to the `ODIM` directory.
-
-   ```
-   cd ODIM
-   ```
-
-9. Save the Cisco ACI plugin Docker image on the deployment node at `~/plugins/aciplugin`.
+8. Save the Cisco ACI plugin Docker image on the deployment node at `~/plugins/aciplugin`.
 
    ```
    docker save aciplugin:2.0 -o ~/plugins/aciplugin/aciplugin.tar


### PR DESCRIPTION
Updated relevant feedback items given for the plugin sections in the Getting Started readme:
- Update parameters for ACI plugin (step 13)
- Specify what is default odim_username and odim_password in the section "Adding a plugin into the Resource Aggregator for ODIM framework"
- Replace hardcoded connectionMethodID in sample payload of aci plugin with a variable {ConnectionMethodId} in the section "Adding a plugin into the Resource Aggregator for ODIM framework".
- To verify the added plugins, need to call 2 APIs. Rephrase to this - " A link of the executed task. Performing a GET operation on this task displays the task monitor associated with this operation in the response header".
