### PR TITLE
ACI plugin deployment updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,12 +103,12 @@ Kubernetes cluster is set up and the resource aggregator is successfully deploye
     lbHost: aciplugin
     lbPort: 30086
     logPath: /var/log/aciplugin_logs
-    apicHost: 10.42.0.50
+    apicHost: 192.168.256.256
     apicUserName: admin
     apicPassword: Apic123
     odimURL: https://api:45000
     odimUserName: admin
-    odimPassword: Od!m12$4
+    odimPassword: H/r7PSBpgBafwA2UPPm6CrkGTBT9H0VJX0EQKz61ktpCJbdUXUiJdoX1LoU2JMxPEQPPv2tU4z1BO0HtiELe8muJ7VilCmW51zMWv0D7O+qjV4IxhvZ5EZT4tHqfjJwBSBBZZ5cV11ceic5p8L26soCT8KMNTRhksYVQJXUJnyT6qiNuTrLAIouJ4kj4xIdelpP4Zgzy7fdyd+x+yQP2DPWgCF5fYErmk7H7gxVibay1YUaE6qVAbYypqwRmUHIjnv3VC3qTRyRfwGMWEm+xD5ySNUOocXqUORuFcSPWDpZYXWRKSYnwKA+XZuCdm6KUiqU84Hyq4O5hWLwz51XZ/SutnOIoZoooqKxhMwmqLvAsx8/ndG9m2j+M/Vx+Cm22OWweGMKvXP5xKqR5X2bMybvLbKb+mJLW8WxjM+EI+Y4XpgunRlsaExYRW/4GCg7vWcvQ8Sc5a74n20+sNKqjqs/SgLdmJTzfh/6MN0TSfn8DtALJiN/17KAyTjH/2YO/arguin/eYiMfO9X6avgjy7x2ceOzUJFaWkWEOYMV8Ksm4msvlfhHcZ+2NgIsJRgfZgbO49+K+0jwQ7p7fXv5GOcFJ6HMVPNTJ8kCayU0Yh50bsqv3e7KTIERT1XyI6zXa7LYk5sswOvl7gsndE3vkPddrHg+m194tFo92chsnv0=
    ```
    
 6. Update the following parameters in the plugin configuration file:
@@ -137,23 +137,14 @@ Kubernetes cluster is set up and the resource aggregator is successfully deploye
 
    - **odimUserName**: The username of the default administrator account of Resource Aggregator for ODIM.
 
-   - **odimPassword**: The encrypted password of the default administrator account of Resource Aggregator for ODIM.
-     To generate the encrypted password, run the following command:
-
+   - **odimPassword**: The encrypted password of the default administrator account of Resource Aggregator for ODIM. To generate the encrypted password, run the following command:
+     
+```
+     echo -n '<HPE ODIMRA password>' |openssl pkeyutl -encrypt -inkey <odimCertsPath>/odimra_rsa.private -pkeyopt rsa_padding_mode:oaep -pkeyopt rsa_oaep_md:sha512|openssl base64 -A
      ```
-     echo -n '<odimra_password>' \
-     | openssl pkeyutl -encrypt -inkey \
-     ~/R4H60-11004/odim-controller/\
-     scripts/certs/\
-     <deploymentid>/odimra_rsa.private \
-     -pkeyopt rsa_padding_mode:oaep \
-     -pkeyopt rsa_oaep_md:sha512|openssl
-     \
-     base64 -A
-     ```
-
+   
    Other parameters can have default values. Optionally, you can update them with values based on your requirements. For more information on each parameter, see [Plugin configuration parameters](#plugin-configuration-parameters).
-
+   
 7. Generate the Helm package for the Cisco ACI plugin on the deployment node:
 
    1. Navigate to `PluginCiscoACI/install/Kubernetes/helmcharts`.
@@ -419,6 +410,7 @@ The following table lists all the configuration parameters required to deploy a 
 | username            | Username of the plugin                                       |
 | password            | The encrypted password of the plugin                         |
 | logPath             | The path where the plugin logs are stored. Default path is `/var/log/<plugin_name>_logs`<br/>**Example**: `/var/log/aciplugin_logs`<br/> |
+| odimPassword        | The encrypted password of the default administrator account of Resource Aggregator for ODIM. To generate the encrypted password, run the following command:<br />`echo -n '<HPE ODIMRA password>' |openssl pkeyutl -encrypt -inkey <odimCertsPath>/odimra_rsa.private -pkeyopt rsa_padding_mode:oaep -pkeyopt rsa_oaep_md:sha512|openssl base64 -A` |
 
 ## Resource Aggregator for ODIM default ports
 


### PR DESCRIPTION
- Updated information on passing the encrypted password in odimPassword parameter while deploying ACI plugin
- Update the `odimPassword` parameter in the plugin configuration parameters section
- Replaced `apicHost` with a public IP. 